### PR TITLE
fix: use Intl.Collator for string sorting when available

### DIFF
--- a/lib/update-dependencies.js
+++ b/lib/update-dependencies.js
@@ -1,3 +1,5 @@
+const localeCompare = require('@isaacs/string-locale-compare')('en')
+
 const depTypes = new Set([
   'dependencies',
   'optionalDependencies',
@@ -10,7 +12,7 @@ const orderDeps = (content) => {
   for (const type of depTypes) {
     if (content && content[type]) {
       content[type] = Object.keys(content[type])
-        .sort((a, b) => a.localeCompare(b, 'en'))
+        .sort(localeCompare)
         .reduce((res, key) => {
           res[key] = content[type][key]
           return res

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,15 @@
 {
-  "name": "@npmcli/update-package-json",
+  "name": "@npmcli/package-json",
   "version": "1.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "@npmcli/update-package-json",
+      "name": "@npmcli/package-json",
       "version": "1.0.1",
       "license": "ISC",
       "dependencies": {
+        "@isaacs/string-locale-compare": "^1.1.0",
         "json-parse-even-better-errors": "^2.3.1"
       },
       "devDependencies": {
@@ -385,6 +386,11 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/@isaacs/string-locale-compare": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@isaacs/string-locale-compare/-/string-locale-compare-1.1.0.tgz",
+      "integrity": "sha512-SQ7Kzhh9+D+ZW9MA0zkYv3VXhIDNx+LzM6EJ+/65I3QY+enU6Itte7E5XX7EWrqLW2FN4n06GWzBnPoC3th2aQ=="
     },
     "node_modules/@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
@@ -7181,6 +7187,11 @@
           "peer": true
         }
       }
+    },
+    "@isaacs/string-locale-compare": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@isaacs/string-locale-compare/-/string-locale-compare-1.1.0.tgz",
+      "integrity": "sha512-SQ7Kzhh9+D+ZW9MA0zkYv3VXhIDNx+LzM6EJ+/65I3QY+enU6Itte7E5XX7EWrqLW2FN4n06GWzBnPoC3th2aQ=="
     },
     "@istanbuljs/load-nyc-config": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "tap": "^15.0.9"
   },
   "dependencies": {
+    "@isaacs/string-locale-compare": "^1.1.0",
     "json-parse-even-better-errors": "^2.3.1"
   }
 }


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->

This applies https://github.com/npm/arborist/pull/324, which should make sorting faster.


## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
