### PR TITLE
fix: dont use `localeCompare` for sorting

### DIFF
--- a/lib/update-dependencies.js
+++ b/lib/update-dependencies.js
@@ -10,7 +10,7 @@ const orderDeps = (content) => {
   for (const type of depTypes) {
     if (content && content[type]) {
       content[type] = Object.keys(content[type])
-        .sort((a, b) => a.localeCompare(b, 'en'))
+        .sort()
         .reduce((res, key) => {
           res[key] = content[type][key]
           return res


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->

Based on https://github.com/npm/cli/issues/3935 & [this comment](https://github.com/yarnpkg/berry/issues/3648#issuecomment-952351470)

## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
