### PR TITLE
fix(perf): lazy load un-common dependencies for npm run

### DIFF
--- a/lib/normalize.js
+++ b/lib/normalize.js
@@ -1,11 +1,8 @@
 const semver = require('semver')
 const fs = require('fs/promises')
 const { glob } = require('glob')
-const legacyFixer = require('normalize-package-data/lib/fixer.js')
-const legacyMakeWarning = require('normalize-package-data/lib/make_warning.js')
 const path = require('path')
 const log = require('proc-log')
-const git = require('@npmcli/git')
 const hostedGitInfo = require('hosted-git-info')
 
 // used to be npm-normalize-package-bin
@@ -333,6 +330,7 @@ const normalize = async (pkg, { strict, steps, root, changes, allowLegacyCase })
 
   // populate "gitHead" attribute
   if (steps.includes('gitHead') && !data.gitHead) {
+    const git = require('@npmcli/git')
     const gitRoot = await git.find({ cwd: pkg.path, root })
     let head
     if (gitRoot) {
@@ -518,6 +516,8 @@ const normalize = async (pkg, { strict, steps, root, changes, allowLegacyCase })
   }
 
   if (steps.includes('normalizeData')) {
+    const legacyFixer = require('normalize-package-data/lib/fixer.js')
+    const legacyMakeWarning = require('normalize-package-data/lib/make_warning.js')
     legacyFixer.warn = function () {
       changes?.push(legacyMakeWarning.apply(null, arguments))
     }


### PR DESCRIPTION
I know we avoid lazy loading but I think this case is worthy:

Before:

```bash
$ hyperfine --warmup 3 "node ./bin/npm-cli.js run empty"
Benchmark 1: node ./bin/npm-cli.js run empty
  Time (mean ± σ):     197.3 ms ±   3.5 ms    [User: 183.1 ms, System: 51.9 ms]
  Range (min … max):   193.2 ms … 207.5 ms    15 runs
```

After:

```bash
$ hyperfine --warmup 3 "node ./bin/npm-cli.js run empty"
Benchmark 1: node ./bin/npm-cli.js run empty
  Time (mean ± σ):     184.6 ms ±   2.3 ms    [User: 170.1 ms, System: 51.1 ms]
  Range (min … max):   181.6 ms … 190.5 ms    16 runs
```