### PR TITLE
perf: only import necessary functions from semver

### DIFF
--- a/lib/normalize.js
+++ b/lib/normalize.js
@@ -1,4 +1,5 @@
-const semver = require('semver')
+const valid = require('semver/functions/valid')
+const clean = require('semver/functions/clean')
 const fs = require('fs/promises')
 const { glob } = require('glob')
 const legacyFixer = require('normalize-package-data/lib/fixer.js')
@@ -130,10 +131,10 @@ const normalize = async (pkg, { strict, steps, root, changes, allowLegacyCase })
     if (!data.version) {
       data.version = ''
     } else {
-      if (!semver.valid(data.version, loose)) {
+      if (!valid(data.version, loose)) {
         throw new Error(`Invalid version: "${data.version}"`)
       }
-      const version = semver.clean(data.version, loose)
+      const version = clean(data.version, loose)
       if (version !== data.version) {
         changes?.push(`"version" was cleaned and set to "${version}"`)
         data.version = version


### PR DESCRIPTION
Just saving a couple of ms by only importing what is needed.