### PR TITLE
fix(perf): lazy load hosted git info on normalize

### DIFF
--- a/lib/normalize.js
+++ b/lib/normalize.js
@@ -4,7 +4,17 @@ const fs = require('fs/promises')
 const { glob } = require('glob')
 const path = require('path')
 const log = require('proc-log')
-const hostedGitInfo = require('hosted-git-info')
+
+/**
+ * @type {import('hosted-git-info')}
+ */
+let _hostedGitInfo
+function lazyHostedGitInfo () {
+  if (!_hostedGitInfo) {
+    _hostedGitInfo = require('hosted-git-info')
+  }
+  return _hostedGitInfo
+}
 
 // used to be npm-normalize-package-bin
 function normalizePackageBin (pkg, changes) {
@@ -445,7 +455,7 @@ const normalize = async (pkg, { strict, steps, root, changes, allowLegacyCase })
         }
       }
       if (data.repository.url) {
-        const hosted = hostedGitInfo.fromUrl(data.repository.url)
+        const hosted = lazyHostedGitInfo().fromUrl(data.repository.url)
         let r
         if (hosted) {
           if (hosted.getDefaultRepresentation() === 'shortcut') {
@@ -505,7 +515,7 @@ const normalize = async (pkg, { strict, steps, root, changes, allowLegacyCase })
               changes?.push(`Removed invalid "${deps}.${d}"`)
               delete data[deps][d]
             }
-            const hosted = hostedGitInfo.fromUrl(data[deps][d])?.toString()
+            const hosted = lazyHostedGitInfo().fromUrl(data[deps][d])?.toString()
             if (hosted && hosted !== data[deps][d]) {
               changes?.push(`Normalized git reference to "${deps}.${d}"`)
               data[deps][d] = hosted.toString()


### PR DESCRIPTION
Combined with #89, we can reduce the load time of `normalize` to less than `1ms`, making the `run-script` load in `4ms` instead of `13ms`.