### PR TITLE
feat: add fromContent method to set contents directly

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -167,6 +167,12 @@ class PackageJson {
     return this
   }
 
+  fromContent (data) {
+    this.#manifest = data
+    this.#canSave = false
+    return this
+  }
+
   // Load data from a comment
   // /**package { "name": "foo", "version": "1.2.3", ... } **/
   fromComment (data) {

--- a/test/index.js
+++ b/test/index.js
@@ -225,3 +225,11 @@ t.test('cannot update with no content', async t => {
     message: /Can not update without content/,
   })
 })
+
+t.test('can set data', async t => {
+  const p = new PackageJson().fromContent({ data: 1 })
+  t.strictSame(p.content, { data: 1 })
+  await t.rejects(p.save(), {
+    message: /No package\.json to save to/,
+  })
+})


### PR DESCRIPTION
Currently to replace `read-package-json-fast` in `pacote` we already have a manifest that needs normalizing. The only way to do that currently is to pass in a string and re-JSON.parse it which is a waste. This allows for content to be set directly.