### PR TITLE
fix: hidden dir path clean up corrected

### DIFF
--- a/lib/normalize.js
+++ b/lib/normalize.js
@@ -127,13 +127,9 @@ function unixifyPath (ref) {
   return ref.replace(/\\|:/g, '/')
 }
 
-function securePath (ref) {
-  const secured = path.join('.', path.join('/', unixifyPath(ref)))
-  return secured.startsWith('.') ? '' : secured
-}
-
 function secureAndUnixifyPath (ref) {
-  return unixifyPath(securePath(ref))
+  const secured = unixifyPath(path.join('.', path.join('/', unixifyPath(ref))))
+  return secured.startsWith('./') ? '' : secured
 }
 
 // We don't want the `changes` array in here by default because this is a hot
@@ -376,7 +372,7 @@ const normalize = async (pkg, { strict, steps, root, changes, allowLegacyCase })
 
   // expand "directories.bin"
   if (steps.includes('binDir') && data.directories?.bin && !data.bin) {
-    const binsDir = path.resolve(pkg.path, securePath(data.directories.bin))
+    const binsDir = path.resolve(pkg.path, secureAndUnixifyPath(data.directories.bin))
     const bins = await lazyLoadGlob()('**', { cwd: binsDir })
     data.bin = bins.reduce((acc, binFile) => {
       if (binFile && !binFile.startsWith('.')) {

--- a/test/prepare.js
+++ b/test/prepare.js
@@ -156,6 +156,19 @@ for (const [name, testPrepare] of Object.entries(testMethods)) {
         t.strictSame(content.bin, { echo: 'bin/echo' })
       })
 
+      t.test('bin handles hidden folders', async t => {
+        const { content } = await testPrepare(t, ({
+          'package.json': JSON.stringify({
+            name: 'bin-test',
+            bin: {
+              echo: '..\\..\\..\\.bin\\echo',
+            },
+          }),
+          bin: { echo: '#!/bin/sh\n\necho "hello world"' },
+        }))
+        t.strictSame(content.bin, { echo: '.bin/echo' })
+      })
+
       t.test('directories.bin with bin', async t => {
         const { content } = await testPrepare(t, ({
           'package.json': JSON.stringify({
@@ -175,6 +188,25 @@ for (const [name, testPrepare] of Object.entries(testMethods)) {
         t.strictSame(content.bin, { echo: 'bin/echo' })
       })
 
+      t.test('directories.bin with hidden bin dir', async t => {
+        const { content } = await testPrepare(t, ({
+          'package.json': JSON.stringify({
+            name: 'bin-test',
+            directories: {
+              bin: './.bin',
+            },
+            bin: {
+              echo: './.bin/echo',
+            },
+          }),
+          bin: {
+            echo: '#!/bin/sh\n\necho "hello world"',
+            echo2: '#!/bin/sh\n\necho "hello world2"',
+          },
+        }))
+        t.strictSame(content.bin, { echo: '.bin/echo' })
+      })
+
       t.end()
     })
 
@@ -187,6 +219,16 @@ for (const [name, testPrepare] of Object.entries(testMethods)) {
           man: { man1: { 'test.1': 'man test file' } },
         }))
         t.strictSame(content.man, ['man/man1/test.1'])
+      })
+
+      t.test('resolves hidden directory', async t => {
+        const { content } = await testPrepare(t, ({
+          'package.json': JSON.stringify({
+            directories: { man: './.man' },
+          }),
+          '.man': { man1: { 'test.1': 'man test file' } },
+        }))
+        t.strictSame(content.man, ['.man/man1/test.1'])
       })
 
       if (name === '@npmcli/package-json') {


### PR DESCRIPTION
Path normalization done in https://github.com/npm/package-json/pull/105 resulted in the removal of `bin` paths that start with `. (hidden directory)`. This PR corrects the path normalization to allow `bin` paths that start with `. (hidden directory)`.


## References
Fixes https://github.com/npm/package-json/issues/116 & https://github.com/npm/cli/issues/7728

