### PR TITLE
fix: correct main entry for relative path

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -34,6 +34,7 @@ class PackageJson {
     'scripts',
     'funding',
     'bin',
+    'main',
   ])
 
   // npm pkg fix
@@ -47,6 +48,7 @@ class PackageJson {
     'fixDependencies',
     'devDependencies',
     'scriptpath',
+    'main',
   ])
 
   static prepareSteps = Object.freeze([
@@ -61,6 +63,7 @@ class PackageJson {
     'authors',
     'readme',
     'mans',
+    'main',
     'binDir',
     'gitHead',
     'fillTypes',

--- a/lib/normalize.js
+++ b/lib/normalize.js
@@ -610,6 +610,11 @@ const normalize = async (pkg, { strict, steps, root, changes, allowLegacyCase })
       }
     }
   }
-}
 
+  if (steps.includes('main') && data.main) {
+    const main = secureAndUnixifyPath(data.main)
+    changes?.push(`"main" was normalized to "${main}"`)
+    data.main = main
+  }
+}
 module.exports = normalize

--- a/tap-snapshots/test/normalize.js.test.cjs
+++ b/tap-snapshots/test/normalize.js.test.cjs
@@ -122,6 +122,13 @@ Array [
 ]
 `
 
+exports[`test/normalize.js TAP @npmcli/package-json - with changes main convert main string to correct path > must match snapshot 1`] = `
+Array [
+  "Deleted incorrect \\"bundledDependencies\\"",
+  "\\"main\\" was normalized to \\"index.js\\"",
+]
+`
+
 exports[`test/normalize.js TAP @npmcli/package-json - with changes normalize bin > must match snapshot 1`] = `
 Array [
   "Deleted incorrect \\"bundledDependencies\\"",

--- a/test/normalize.js
+++ b/test/normalize.js
@@ -338,6 +338,19 @@ for (const [name, testNormalize] of Object.entries(testMethods)) {
       t.has(content, { bin: undefined })
     })
 
+    t.test('main', t => {
+      if (isLegacy) {
+        return t.skip('rpj does not have configurable steps for main')
+      }
+      t.test('convert main string to correct path', async t => {
+        const { content: { main } } = await testNormalize(t, ({
+          'package.json': JSON.stringify({ main: './index.js' }),
+        }))
+        t.strictSame(main, 'index.js')
+      })
+      t.end()
+    })
+
     t.test('skipping steps', async t => {
       if (isLegacy) {
         return t.skip('rpj does not have configurable steps')


### PR DESCRIPTION
`npm-packlist` gets normalized package-json when assessing files to include. when `main` is specified with relative file path it doesn't consider that entry when including files. Fixing main in normalization step 

- [ ] check on changes condition 
- [ ] sanity testing

Fixes: https://github.com/npm/cli/issues/7799