### PR TITLE
chore: switch to tinyglobby

### DIFF
--- a/lib/normalize.js
+++ b/lib/normalize.js
@@ -16,12 +16,12 @@ function lazyHostedGitInfo () {
 }
 
 /**
- * @type {import('glob').glob}
+ * @type {import('tinyglobby').glob}
  */
 let _glob
 function lazyLoadGlob () {
   if (!_glob) {
-    _glob = require('glob').glob
+    _glob = require('tinyglobby').glob
   }
   return _glob
 }

--- a/package.json
+++ b/package.json
@@ -30,11 +30,11 @@
   },
   "dependencies": {
     "@npmcli/git": "^6.0.0",
-    "glob": "^10.2.2",
     "hosted-git-info": "^8.0.0",
     "json-parse-even-better-errors": "^4.0.0",
     "proc-log": "^5.0.0",
     "semver": "^7.5.3",
+    "tinyglobby": "^0.2.11",
     "validate-npm-package-license": "^3.0.4"
   },
   "devDependencies": {


### PR DESCRIPTION
https://npmgraph.js.org/?q=glob@10.2.1 - 27 dependencies
https://npmgraph.js.org/?q=tinyglobby - 2 dependencies

Also, all versions of `glob` prior to v9 have been deprecated. This also avoids the possibility that the version here might be deprecated one day as well

<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->

## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
