### PR TITLE
Add step to normalize, fix logging bug

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -34,6 +34,7 @@ class PackageJson {
     'scripts',
     'funding',
     'bin',
+    'binDir',
   ])
 
   // npm pkg fix
@@ -111,7 +112,7 @@ class PackageJson {
     return p.prepare(opts)
   }
 
-  // read-package-json-fast compatible behavior
+  // read-package-json-fast.normalize compatible behavior (distinct from just read-package-json-fast
   static async normalize (path, opts) {
     const p = new PackageJson()
     await p.load(path)

--- a/lib/normalize.js
+++ b/lib/normalize.js
@@ -210,8 +210,8 @@ const normalize = async (pkg, { strict, steps, root, changes, allowLegacyCase })
   if (steps.includes('bundledDependencies')) {
     if (data.bundleDependencies === undefined && data.bundledDependencies !== undefined) {
       data.bundleDependencies = data.bundledDependencies
+      changes?.push(`Deleted incorrect "bundledDependencies"`)
     }
-    changes?.push(`Deleted incorrect "bundledDependencies"`)
     delete data.bundledDependencies
   }
   // expand "bundleDependencies: true or translate from object"

--- a/tap-snapshots/test/normalize.js.test.cjs
+++ b/tap-snapshots/test/normalize.js.test.cjs
@@ -12,35 +12,29 @@ Array [
 `
 
 exports[`test/normalize.js TAP @npmcli/package-json - with changes clean up bundleDependencies dont array-ify if its an array already > must match snapshot 1`] = `
-Array [
-  "Deleted incorrect \\"bundledDependencies\\"",
-]
+Array []
 `
 
 exports[`test/normalize.js TAP @npmcli/package-json - with changes clean up bundleDependencies handle bundleDependencies object > must match snapshot 1`] = `
 Array [
-  "Deleted incorrect \\"bundledDependencies\\"",
   "\\"bundleDependencies\\" was changed from an object to an array",
 ]
 `
 
 exports[`test/normalize.js TAP @npmcli/package-json - with changes clean up bundleDependencies handle bundleDependencies: false > must match snapshot 1`] = `
 Array [
-  "Deleted incorrect \\"bundledDependencies\\"",
   "\\"bundleDependencies\\" was changed from \\"false\\" to \\"[]\\"",
 ]
 `
 
 exports[`test/normalize.js TAP @npmcli/package-json - with changes clean up bundleDependencies handle bundleDependencies: true > must match snapshot 1`] = `
 Array [
-  "Deleted incorrect \\"bundledDependencies\\"",
   "\\"bundleDependencies\\" was auto-populated from \\"dependencies\\"",
 ]
 `
 
 exports[`test/normalize.js TAP @npmcli/package-json - with changes clean up bundleDependencies handle bundleDependencies: true with no deps > must match snapshot 1`] = `
 Array [
-  "Deleted incorrect \\"bundledDependencies\\"",
   "\\"bundleDependencies\\" was auto-populated from \\"dependencies\\"",
 ]
 `
@@ -54,41 +48,33 @@ Array [
 
 exports[`test/normalize.js TAP @npmcli/package-json - with changes clean up scripts delete non-object scripts > must match snapshot 1`] = `
 Array [
-  "Deleted incorrect \\"bundledDependencies\\"",
   "Removed invalid \\"scripts\\"",
 ]
 `
 
 exports[`test/normalize.js TAP @npmcli/package-json - with changes clean up scripts delete non-string script targets > must match snapshot 1`] = `
 Array [
-  "Deleted incorrect \\"bundledDependencies\\"",
   "Invalid scripts.\\"bar\\" was removed",
   "Invalid scripts.\\"baz\\" was removed",
 ]
 `
 
 exports[`test/normalize.js TAP @npmcli/package-json - with changes cleanup bins delete string bin when no name > must match snapshot 1`] = `
-Array [
-  "Deleted incorrect \\"bundledDependencies\\"",
-]
+Array []
 `
 
 exports[`test/normalize.js TAP @npmcli/package-json - with changes cleanup bins handle string when a name is set > must match snapshot 1`] = `
 Array [
-  "Deleted incorrect \\"bundledDependencies\\"",
   "\\"bin\\" was converted to an object",
 ]
 `
 
 exports[`test/normalize.js TAP @npmcli/package-json - with changes cleanup bins remove non-object bin > must match snapshot 1`] = `
-Array [
-  "Deleted incorrect \\"bundledDependencies\\"",
-]
+Array []
 `
 
 exports[`test/normalize.js TAP @npmcli/package-json - with changes cleanup bins remove non-string bin values > must match snapshot 1`] = `
 Array [
-  "Deleted incorrect \\"bundledDependencies\\"",
   "removed invalid \\"bin[y]\\"",
   "removed invalid \\"bin[z]\\"",
 ]
@@ -96,42 +82,34 @@ Array [
 
 exports[`test/normalize.js TAP @npmcli/package-json - with changes convert funding string to object > must match snapshot 1`] = `
 Array [
-  "Deleted incorrect \\"bundledDependencies\\"",
   "\\"funding\\" was changed to an object with a url attribute",
 ]
 `
 
 exports[`test/normalize.js TAP @npmcli/package-json - with changes dedupe optional deps out of regular deps choose optional deps in conflict, leaving populated dependencies > must match snapshot 1`] = `
 Array [
-  "Deleted incorrect \\"bundledDependencies\\"",
   "optionalDependencies.\\"whowins\\" was removed",
 ]
 `
 
 exports[`test/normalize.js TAP @npmcli/package-json - with changes dedupe optional deps out of regular deps choose optional deps in conflict, removing empty dependencies > must match snapshot 1`] = `
 Array [
-  "Deleted incorrect \\"bundledDependencies\\"",
   "optionalDependencies.\\"whowins\\" was removed",
   "Empty \\"optionalDependencies\\" was removed",
 ]
 `
 
 exports[`test/normalize.js TAP @npmcli/package-json - with changes dedupe optional deps out of regular deps do not create regular deps if only optional specified > must match snapshot 1`] = `
-Array [
-  "Deleted incorrect \\"bundledDependencies\\"",
-]
+Array []
 `
 
 exports[`test/normalize.js TAP @npmcli/package-json - with changes normalize bin > must match snapshot 1`] = `
-Array [
-  "Deleted incorrect \\"bundledDependencies\\"",
-]
+Array []
 `
 
 exports[`test/normalize.js TAP @npmcli/package-json - with changes set _id if name and version set > must match snapshot 1`] = `
 Array [
   "\\"_id\\" was set to a@1.2.3",
-  "Deleted incorrect \\"bundledDependencies\\"",
 ]
 `
 
@@ -143,6 +121,5 @@ exports[`test/normalize.js TAP @npmcli/package-json - with changes strip _fields
 Array [
   "\\"_lodash\\" was removed",
   "\\"_id\\" was set to underscore@1.2.3",
-  "Deleted incorrect \\"bundledDependencies\\"",
 ]
 `

--- a/tap-snapshots/test/normalize.js.test.cjs
+++ b/tap-snapshots/test/normalize.js.test.cjs
@@ -103,6 +103,10 @@ exports[`test/normalize.js TAP @npmcli/package-json - with changes dedupe option
 Array []
 `
 
+exports[`test/normalize.js TAP @npmcli/package-json - with changes directories.bin > must match snapshot 1`] = `
+Array []
+`
+
 exports[`test/normalize.js TAP @npmcli/package-json - with changes normalize bin > must match snapshot 1`] = `
 Array []
 `

--- a/test/normalize.js
+++ b/test/normalize.js
@@ -167,6 +167,19 @@ for (const [name, testNormalize] of Object.entries(testMethods)) {
       })
     })
 
+    t.test('directories.bin', async t => {
+      const { content } = await testNormalize(t, ({
+        'package.json': JSON.stringify({
+          name: 'bin-test',
+          directories: {
+            bin: './bin',
+          },
+        }),
+        bin: { echo: '#!/bin/sh\n\necho "hello world"' },
+      }))
+      t.strictSame(content.bin, { echo: 'bin/echo' })
+    })
+
     t.test('dedupe optional deps out of regular deps', async t => {
       t.test('choose optional deps in conflict, removing empty dependencies', async t => {
         const { content } = await testNormalize(t, ({


### PR DESCRIPTION
This adds `binDir` to the `normalize` step. See the individual commit for the full story.

While adding that I noticed another bug where the `bundledDependencies` logging warning was always being emitted, even if there was nothing being done.  This bug is now fixed.


- **fix: remove erroneous bundledDependencies log**
- **feat: add binDir step to normalize function**
