### PR TITLE
fix: comment typo

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -225,7 +225,7 @@ class PackageJson {
       this.#manifest = step({ content, originalContent: this.content })
     }
 
-    // unknown properties will just be overwitten
+    // unknown properties will just be overwritten
     for (const [key, value] of Object.entries(content)) {
       if (!knownKeys.has(key)) {
         this.content[key] = value


### PR DESCRIPTION
Fix what is most likely a typo in a comment in the index.js file of the package-json module.
This is a "duplicate" of a PR made to the CLI repository (https://github.com/npm/cli/pull/8591), which was closed due to it being the wrong repository.